### PR TITLE
Revert "Replace broken JSON encoder"

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,4 @@
 Revision history for Pastebin-Gist
 
-1.001002  2015-12-13
-  - Replaced buggy JSON encoder
-
 1.001001  2015-10-11
   - First version released on an unsuspecting world

--- a/META6.json
+++ b/META6.json
@@ -1,9 +1,9 @@
 {
     "perl"         : "6.c",
     "name"         : "Pastebin::Gist",
-    "version"      : "1.001002",
+    "version"      : "1.001001",
     "description"  : "Use https://gist.github.com/ as a pastebin",
-    "depends"      : [ "HTTP::Tinyish", "JSON::Tiny" ],
+    "depends"      : [ "HTTP::Tinyish", "JSON::Fast" ],
     "test-depends" : [ "Test" ],
     "provides"     : {
         "Pastebin::Gist" : "lib/Pastebin/Gist.pm6"

--- a/lib/Pastebin/Gist.pm6
+++ b/lib/Pastebin/Gist.pm6
@@ -1,5 +1,5 @@
 use HTTP::Tinyish;
-use JSON::Tiny;
+use JSON::Fast;
 unit class Pastebin::Gist:ver<1.001001>;
 
 constant API-URL   = 'https://api.github.com/';


### PR DESCRIPTION
JSON::Fast in version 0.8.3 now deals with lone combiners
at the start of a string and it also properly escapes all
control characters.