### PR TITLE
Allow anonymous gists

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -2,7 +2,7 @@
     "perl"         : "6.c",
     "name"         : "Pastebin::Gist",
     "license"      : "Artistic-2.0",
-    "version"      : "1.004001",
+    "version"      : "1.004002",
     "description"  : "Use https://gist.github.com/ as a pastebin",
     "depends"      : [ "WWW", "JSON::Fast" ],
     "test-depends" : [ "Test" ],

--- a/README.pod
+++ b/README.pod
@@ -45,12 +45,16 @@ Creates new C<Pastebin::Gist> object. Accepts the following settings:
 
     token => '3f2b4ca292960fafc63fb6798f148e3b47ea9fff'
 
-B<Mandatory>. To use this module you need to
+To use this module you need to
 L<create a GitHub token|https://github.com/settings/tokens>. Only the C<gist>
 permission is needed.
 
 You can avoid providing the C<token> argument by setting the
 C<PASTEBIN_GIST_TOKEN> environmental variable to the value of your token.
+
+Also, you can upload
+[anonymous gists](https://help.github.com/articles/about-gists/#anonymous-gists)
+by providing no token.
 
 =head2 C<paste>
 

--- a/lib/Pastebin/Gist.pm6
+++ b/lib/Pastebin/Gist.pm6
@@ -10,7 +10,7 @@ constant PASTE-URL = 'https://gist.github.com/';
 constant %UA       = :User-Agent('Rakudo Pastebin::Gist');
 
 subset ValidGistToken of Str where /:i <[a..f 0..9]> ** 40/;
-has ValidGistToken $.token = %*ENV<PASTEBIN_GIST_TOKEN>;
+has ValidGistToken $.token = %*ENV<PASTEBIN_GIST_TOKEN> // Nil;
 
 method paste (
     $paste,
@@ -25,7 +25,8 @@ method paste (
                                     !! { $filename => { content => $paste } };
 
     my $res = jpost API-URL ~ 'gists', %content.&to-json,
-        |%UA, :Authorization("token $!token"), :Content-Type<application/json>
+        |%UA, :Authorization($!token.defined ?? "token $!token" !! Empty),
+        :Content-Type<application/json>
     orelse die X.new: :message(.exception.message);
 
     return PASTE-URL ~ $res<id>;


### PR DESCRIPTION
By making the token optional. Noticed this issue when one user was
attempting to run whateverable locally without giving a
token. Obviously, you shouldn't need a github account just to run a
bot, so having a way to use anonymous gists with this module would be
great.

Also, notice that example/paste.pl6 shows how to use the module
*without a token* (doesn't even have it stubbed). With this change the
example runs more or less successfuly. It does not seem to delete
anything, which I guess makes sense, so the example needs some editing
probably.

Tests clean.